### PR TITLE
Output a message about how long the script will sleep

### DIFF
--- a/templates/ansible-pull-script.sh.j2
+++ b/templates/ansible-pull-script.sh.j2
@@ -47,6 +47,7 @@ then
 fi
 
 # Sleep a bit
+$loggercmd "Sleeping for ${time}s until $(date -d @$(($(date +%s) + $time)))"
 /bin/sleep "$time"s
 
 # Clone or update the fgci-ansible repo


### PR DESCRIPTION
So users don't get confused and think the script is stuck.
