### PR TITLE
Make getting the latest ansible-pull-script.sh more robust

### DIFF
--- a/templates/ansible-pull-script.sh.j2
+++ b/templates/ansible-pull-script.sh.j2
@@ -120,8 +120,10 @@ fi
 {% endif %}
 
 # Grab the latest ansible-pull-script.sh
-/usr/bin/curl -f -o /usr/local/bin/ansible-pull-script.sh http://{{ pull_install_ip }}/ansible-pull-script.sh
+/usr/bin/curl -f -o /usr/local/bin/ansible-pull-script.sh.new http://{{ pull_install_ip }}/ansible-pull-script.sh
 if [ "$?" != 0 ]; then
-        $loggercmd "error: curl -f -o /usr/local/bin/ansible-pull-script.sh http://{{ pull_install_ip }}/ansible-pull-script.sh failed with rc=$?"
+    $loggercmd "error: curl -f -o /usr/local/bin/ansible-pull-script.sh.new http://{{ pull_install_ip }}/ansible-pull-script.sh failed with rc=$?"
+else
+    mv /usr/local/bin/ansible-pull-script.sh.new /usr/local/bin/ansible-pull-script.sh
+    chmod 0750 /usr/local/bin/ansible-pull-script.sh
 fi
-chmod 0750 /usr/local/bin/ansible-pull-script.sh


### PR DESCRIPTION
By downloading the latest version to a temporary name and then renaming
that over the old one we gain a few benefits: 1) If the downloading
fails partway through, we won't corrupt the script. 2) Renaming within
a filesystem is guaranteed to be atomic, and won't change the script
we're currently running.
