### PR TITLE
Exclude vim swap-files from group_vars rsync

### DIFF
--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -35,6 +35,7 @@
                 rsync_opts:
                  - '--exclude=secrets.yml'
                  - '--exclude=trusted_networks.yml'
+                 - '--exclude=*.swp'
   when: ansible_virtualization_type != "docker"
 
 - name: synchronize host_vars for ansible-pull if the directory exsts


### PR DESCRIPTION
At least I seem to leave those vim's to background ;-/  
