### PR TITLE
Set DISPLAY_SKIPPED_HOSTS=0 for ansible

### DIFF
--- a/templates/ansible-pull-script.sh.j2
+++ b/templates/ansible-pull-script.sh.j2
@@ -15,6 +15,8 @@ time=$[ ( $RANDOM % {{ ansible_pull_sleep }} )  + 1 ]
 lockdir="/var/lock/ansible-pull"
 WORKDIR="workdir"
 FULL_WORKDIR="/root/.ansible/pull/workdir"
+# Make ansible not print skipped hosts
+export DISPLAY_SKIPPED_HOSTS=0
 
 # Command line option handling. Only -n (= no sleep, useful for
 # interactive use) is supported so far.


### PR DESCRIPTION
By not printing skipped hosts the output is a lot shorter, especially
ansible-role-sshd-host-keys otherwise prints a line for every node
multiple times.
