### PR TITLE
allow logging ansible-pull output to a file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,10 @@ gitmirror_basepath: "/var/local/gitmirror"
 
 # Set to False to disable the grafana annotations
 ansible_pull_grafana_annotation: True
+
+# Logging
+ansible_pull_log: False
+ansible_pull_log_path: "/var/log/ansible-pull.log"
+ansible_pull_logrotate: False
+ansible_pull_logrotate_interval: daily
+ansible_pull_logrotate_rotate: 16

--- a/tasks/compute.yml
+++ b/tasks/compute.yml
@@ -4,3 +4,7 @@
 
 - name: template the ansible-pull-script.sh to /usr/local/bin
   template: src=ansible-pull-script.sh.j2 dest=/usr/local/bin/ansible-pull-script.sh mode=0755 backup=no
+
+- name: template the ansible_pull_logrotate.j2 to /etc/logrotate.d/ansible_pull
+  template: src=ansible_pull_logrotate.j2 dest=/etc/logrotate.d/ansible_pull mode=0644 backup=no
+  when: ansible_pull_log and ansible_pull_logrotate

--- a/templates/ansible-pull-script.sh.j2
+++ b/templates/ansible-pull-script.sh.j2
@@ -17,6 +17,10 @@ WORKDIR="workdir"
 FULL_WORKDIR="/root/.ansible/pull/workdir"
 # Make ansible not print skipped hosts
 export DISPLAY_SKIPPED_HOSTS=0
+{% if ansible_pull_log is True %}
+# Make ansible log to a file
+ANSIBLE_LOG_PATH={{ ansible_pull_log_path }}
+{% endif %}
 
 # Command line option handling. Only -n (= no sleep, useful for
 # interactive use) is supported so far.

--- a/templates/ansible_pull_logrotate.j2
+++ b/templates/ansible_pull_logrotate.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+{% if ansible_pull_logrotate is True %}
+{{ ansible_pull_log_path }} {
+	{{ ansible_pull_logrotate_interval }}
+	missingok
+	notifempty
+	rotate {{ ansible_pull_logrotate_rotate }}
+	copytruncate
+	compress
+	delaycompress
+	create 640 root root
+}
+{% endif %}


### PR DESCRIPTION
Making a PR of this - because this needs a bit more testing than I've currently done (that defining the setting in ansible.cfg works). I'd also like to have tested on our test system that this works and especially that the logrotate script works.

Four new variables, these are the defaults:

<pre>
ansible_pull_log: False
ansible_pull_log_path: "/var/log/ansible-pull.log"
ansible_pull_logrotate: False
ansible_pull_logrotate_interval: daily
ansible_pull_logrotate_rotate: 16
</pre>


This does not change the /var/log/ansible.log which currently only has
the last ansible-pull output.

Maybe in the future if we run ansible-pull via a systemd service the
output could be kept in systemd journal.
