### PR TITLE
Use rsync instead of wget for mirroring group_vars and host_vars

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,5 @@
 ---
 # handlers file for ansible-role-fgci-install
+
+- name: restart rsyncd
+  service: name=rsyncd state=restarted

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -46,6 +46,13 @@
                 group: no
   when: ansible_virtualization_type != "docker" and reg_host_vars_src.stat.exists
 
+- name: Generate rsyncd.conf
+  template: src=rsyncd.conf.j2 dest=/etc/rsyncd.conf mode=0644
+  notify: restart rsyncd
+
+- name: Enable rsyncd
+  service: name=rsyncd state=started enabled=yes
+
 - name: template the ansible-pull-script.sh to /var/www/html - for ansible-pull
   template: src=ansible-pull-script.sh.j2 dest=/var/www/html/ansible-pull-script.sh mode=0644 backup=yes
   when: ansible_virtualization_type != "docker"
@@ -68,10 +75,3 @@
 - name: Bounce gitmirror service, but do not fail if it does not exist yet
   service: name=gitmirror state=restarted
   ignore_errors: yes
-
-- name: Generate rsyncd.conf
-  template: src=rsyncd.conf.j2 dest=/etc/rsyncd.conf mode=0644
-  notify: restart rsyncd
-
-- name: Enable rsyncd
-  service: name=rsyncd state=started enabled=yes

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -68,3 +68,10 @@
 - name: Bounce gitmirror service, but do not fail if it does not exist yet
   service: name=gitmirror state=restarted
   ignore_errors: yes
+
+- name: Generate rsyncd.conf
+  template: src=rsyncd.conf.j2 dest=/etc/rsyncd.conf mode=0644
+  notify: restart rsyncd
+
+- name: Enable rsyncd
+  service: name=rsyncd state=started enabled=yes

--- a/templates/ansible-pull-script.sh.j2
+++ b/templates/ansible-pull-script.sh.j2
@@ -74,7 +74,7 @@ sleep_pid=
 start_time="$(($(awk '/^now/ {print $3; exit}' /proc/timer_list)/1000000000))"
 
 #if $FULL_WORKDIR/.git does not exist we need to do a git clone ourselves.
-#ansible-pull / git can't do this with a non-empty directory, which we have because we need to wget mirror in the group_vars from each cluster's install node before we run ansible-pull.
+#ansible-pull / git can't do this with a non-empty directory, which we have because we need to rsync mirror in the group_vars from each cluster's install node before we run ansible-pull.
 if [ ! -d "$FULL_WORKDIR/.git" ]; then
     	/usr/bin/git clone http://{{ pull_install_ip }}:8080/github.com/CSC-IT-Center-for-Science/fgci-ansible.git $FULL_WORKDIR
 	if [ "$?" != 0 ]; then
@@ -88,11 +88,11 @@ else
 fi
 
 # Mirror in the group_vars - they are copied to install node's www with the fgci-install tag and role for install node.
-# Wget assumes we are in $HOME/.ansible/pull/$WORKDIR when running
-/usr/bin/wget --no-host-directories --mirror --accept=example,yml,fgci-default-packages http://{{ pull_install_ip }}/group_vars
+# rsync assumes we are in $HOME/.ansible/pull/$WORKDIR when running
+/usr/bin/rsync -avzH --delete --delay-updates rsync://{{ pull_install_ip }}/group_vars group_vars
 
 # Mirror the host_vars tree
-/usr/bin/wget --no-host-directories --no-parent --mirror --accept=yml http://{{ pull_install_ip }}/host_vars
+/usr/bin/rsync -avzH --delete --delay-updates rsync://{{ pull_install_ip }}/host_vars host_vars
 
 # Install all the ansible role dependencies
 /usr/bin/curl -f -O http://{{ pull_install_ip }}/requirements_mirror.yml

--- a/templates/ansible-pull-script.sh.j2
+++ b/templates/ansible-pull-script.sh.j2
@@ -89,10 +89,10 @@ fi
 
 # Mirror in the group_vars - they are copied to install node's www with the fgci-install tag and role for install node.
 # rsync assumes we are in $HOME/.ansible/pull/$WORKDIR when running
-/usr/bin/rsync -avzH --delete --delay-updates rsync://{{ pull_install_ip }}/group_vars group_vars
+/usr/bin/rsync -aqzH --delete --delay-updates rsync://{{ pull_install_ip }}/group_vars group_vars
 
 # Mirror the host_vars tree
-/usr/bin/rsync -avzH --delete --delay-updates rsync://{{ pull_install_ip }}/host_vars host_vars
+/usr/bin/rsync -aqzH --delete --delay-updates rsync://{{ pull_install_ip }}/host_vars host_vars
 
 # Install all the ansible role dependencies
 /usr/bin/curl -f -O http://{{ pull_install_ip }}/requirements_mirror.yml

--- a/templates/rsyncd.conf.j2
+++ b/templates/rsyncd.conf.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+
+[group_vars]
+        path = {{ group_vars_dest }}
+        comment = Ansible group_vars
+
+[host_vars]
+	path = {{ host_vars_dest }}
+	comment = Ansible host_vars

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -55,7 +55,7 @@ function install_ansible_devel() {
 
 echo "TEST: building ansible"
 
-yum -y install PyYAML python-paramiko python-jinja2 python-httplib2 rpm-build make python2-devel asciidoc patch wget 2>&1 >/dev/null || (echo "Could not install ansible yum dependencies" && exit 2 )
+yum -y install PyYAML python-paramiko python-jinja2 python-httplib2 rpm-build make python2-devel asciidoc patch rsync 2>&1 >/dev/null || (echo "Could not install ansible yum dependencies" && exit 2 )
 rm -Rf ansible
 git clone https://github.com/ansible/ansible --recursive ||(echo "Could not clone ansible from Github" && exit 2 )
 cd ansible


### PR DESCRIPTION
With the help of the rsync --delete option, this gets rid of files
that have been deleted at the source, which can otherwise cause
problems.

Also, by using rsync instead of wget we save some of our precious
cluster internal bandwidth, since in the vast majority of cases there
are no changes.