### PR TITLE
Rename DISPLAY_SKIPPED_HOSTS to ANSIBLE_DISPLAY_SKIPPED_HOSTS

### DIFF
--- a/templates/ansible-pull-script.sh.j2
+++ b/templates/ansible-pull-script.sh.j2
@@ -16,7 +16,7 @@ lockdir="/var/lock/ansible-pull"
 WORKDIR="workdir"
 FULL_WORKDIR="/root/.ansible/pull/workdir"
 # Make ansible not print skipped hosts
-export DISPLAY_SKIPPED_HOSTS=0
+export ANSIBLE_DISPLAY_SKIPPED_HOSTS=0
 {% if ansible_pull_log == true %}
 # Make ansible log to a file
 export ANSIBLE_LOG_PATH={{ ansible_pull_log_path }}


### PR DESCRIPTION
Running ansible-pull-script.sh prints a deprecation warning. Fix it by
renaming the environment variable DISPLAY_SKIPPED_HOSTS to
ANSIBLE_DISPLAY_SKIPPED_HOSTS.

See https://github.com/ansible/ansible/pull/54272